### PR TITLE
feature/overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,27 +39,30 @@ user experience.
 ### Generate testsuite 
 > Generates testsuite containing testcases for all the api endpoints present in the OAS 3.0 document.
 ```bash
-ats generate [--oaspath <oaspath>] [--testsuitepath <testsuitepath>] [--verbose]
+ats generate [--oaspath <oaspath>] [--testsuitepath <testsuitepath>] [--overridespath <overridespath>] [--verbose]
 ```
 #### Options
 * ```--oaspath <oaspath>```: Path of OAS 3.0 document.
 * ```--testsuitepath <testsuitepath>```: Path where the generated testsuite is saved.
+* ```--overridespath <overridespath>```: Path of Overrides file.
 * ```--verbose```: Provides more information about events that occur through logs.
 #### Examples
-* ``` --oaspath = "/foldername/petstore.json" ```
-* ``` --testsuitepath = "/foldername/petstore_1.0.5_testsuite.json" ```
-* ``` --verbose ```
+* ```--oaspath= "/foldername/petstore.json" ```
+* ```--testsuitepath= "/foldername/petstore_1.0.5_testsuite.json" ```
+* ```--overridespath= "/ats/overrides.json" ```
+* ```--verbose ```
 
 ### Validate API Endpoints
 > Validates the API Endpoints against the OpenAPI Specification.
 ```bash
-ats validate [--testsuitepath <testsuitepath>] [--oaspath <oaspath>] [--baseURL <baseURL>] [--apiendpoints <apiendpoints>]
-[--apikeys <apikeys>] [--basicauth <basicauth>] [--saveconfigto <configpath>] [--uploadconfigfrom <configpath>] 
-[--timeout <timeout>] [--verbose]
+ats validate [--testsuitepath <testsuitepath>] [--oaspath <oaspath>] [--overridespath <overridespath>]
+[--baseURL <baseURL>] [--apiendpoints <apiendpoints>] [--apikeys <apikeys>] [--basicauth <basicauth>] 
+[--saveconfigto <configpath>] [--uploadconfigfrom <configpath>] [--timeout <timeout>] [--verbose]
 ```
 #### Options
 * ```--testsuitepath <testsuitepath>```: Path of testsuite. (App runs testcases present in the testsuite)
 * ```--oaspath <oaspath>```: Path of OAS 3.0 document. (App runs testcases which are generated against the provided OAS 3.0 document)
+* ```--overridespath <overridespath>```: Path of Overrides file.
 * ```--baseURL <baseURL>```: BaseURL
 * ```--apiendpoints <apiendpoints>```: API Endpoints that needs to be validated.
 * ```--apikeys <apikeys>```: API Keys used for Authentication/Authorisation.
@@ -69,16 +72,17 @@ ats validate [--testsuitepath <testsuitepath>] [--oaspath <oaspath>] [--baseURL 
 * ```--timeout <timeout>```: Specifies the number of milliseconds before the request times out. (Default: 5000 ms)
 * ```--verbose```: Provides more descriptive test results and information about events that occur through logs.
 #### Examples
-* ``` --testsuitepath = "/foldername/petstore_1.0.5_testsuite.json" ```
-* ``` --oaspath = "/foldername/petstore.json" ```
-* ```--baseURL = "http://www.ats.com" ```
-* ```--apiendpoints = '[{"path": "/pet", "httpMethod": "post"} , {"path": "/store", "httpMethod": "post"}]'```
-* ```--apikeys = '[{"name": "X-API-KEY", "value":"foo"}, {"name": "X-API-KEY_DUP", "value": "bar"}]' ```
-* ```--basicauth = '{"username": "sundar", "password": "sundar@123"}' ```
-* ```--saveconfigto = "/foldername/petstore_config.json" ```
-* ```--uploadconfigfrom = "/foldername/petstore_config.json" ```
-* ```--timeout = 9000 ```
-* ``` --verbose ```
+* ```--testsuitepath= "/foldername/petstore_1.0.5_testsuite.json" ```
+* ```--oaspath= "/foldername/petstore.json" ```
+* ```--overridespath= "/ats/overrides.json" ```
+* ```--baseURL= "http://www.ats.com" ```
+* ```--apiendpoints= '[{"path": "/pet", "httpMethod": "post"} , {"path": "/store", "httpMethod": "post"}]'```
+* ```--apikeys= '[{"name": "X-API-KEY", "value":"foo"}, {"name": "X-API-KEY_DUP", "value": "bar"}]' ```
+* ```--basicauth= '{"username": "sundar", "password": "sundar@123"}' ```
+* ```--saveconfigto= "/foldername/petstore_config.json" ```
+* ```--uploadconfigfrom= "/foldername/petstore_config.json" ```
+* ```--timeout= 9000 ```
+* ```--verbose ```
 
 Further details on installation and basic requirement details will be added soon.
 

--- a/examples/overrides.json
+++ b/examples/overrides.json
@@ -1,0 +1,13 @@
+{
+  "/pet": {
+    "post": {
+      "requestBody": {
+        "id": 123
+      },
+      "requestHeaders": {
+	     "csrfToken": "asd",
+	     "accept": "*"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2833,6 +2833,11 @@
         "minimist": "^1.2.5"
       }
     },
+    "jsonpath-plus": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-4.0.0.tgz",
+      "integrity": "sha512-e0Jtg4KAzDJKKwzbLaUtinCn0RZseWBVRTRGihSpvFlM3wTR7ExSp+PTdeTsDrLNJUe7L7JYJe8mblHX5SCT6A=="
+    },
     "jsonschema": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.6.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "is-integer": "^1.0.7",
     "is-number": "^7.0.0",
     "json-schema-ref-parser": "^9.0.1",
+    "jsonpath-plus": "^4.0.0",
     "jsonschema": "^1.2.6",
     "lodash": "^4.17.15",
     "mkdirp": "^1.0.4",

--- a/src/cli/actions.js
+++ b/src/cli/actions.js
@@ -74,7 +74,20 @@ async function generateTestSuite(options = {}) {
         [{message: 'TestSuite Path'}]);
     testSuitePath = response.path;
   }
-  createTestSuiteFile(oasDoc, testSuitePath);
+
+  const overridesPath = options.overridespath;
+  let overrides = {};
+  if (overridesPath) {
+    if (isValidJSONFile(overridesPath)) {
+      overrides = getJSONData(overridesPath);
+      logger.verbose(
+          `Uploaded overrides successfully from ${overridesPath}.\n`.magenta);
+    } else {
+      logger.error('Overrides upload failed.'.red);
+      return;
+    }
+  }
+  createTestSuiteFile(oasDoc, testSuitePath, overrides);
 }
 
 /**
@@ -103,12 +116,25 @@ async function validateApiEndpoints(options = {}) {
     }
   }
 
+  const overridesPath = options.overridespath;
+  let overrides = {};
+  if (overridesPath) {
+    if (isValidJSONFile(overridesPath)) {
+      overrides = getJSONData(overridesPath);
+      logger.verbose(
+          `Uploaded overrides successfully from ${overridesPath}.\n`.magenta);
+    } else {
+      logger.error('Overrides upload failed.'.red);
+      return;
+    }
+  }
+
   const oasPath = options.oaspath;
   if (oasPath) {
     if (isValidJSONFile(oasPath)) {
       const oasDoc = getJSONData(oasPath);
       logger.verbose('oas 3.0 document uploaded successfully.\n'.magenta);
-      testSuite = buildTestSuite(oasDoc);
+      testSuite = buildTestSuite(oasDoc, overrides);
       logger.verbose('testsuite created successfully.\n'.magenta);
     } else {
       logger.error('oas 3.0 document upload Failed.'.red);

--- a/src/cli/actions.js
+++ b/src/cli/actions.js
@@ -30,26 +30,8 @@ const {
 } = require('../generators/test_data');
 const {runTestSuite} = require('../testsuite_runner');
 const {buildConfig, getConfig, upsertConfig} = require('../utils/config');
-const {isValidJSONFile, getJSONData} = require('../utils/app');
+const {readFile} = require('../utils/app');
 const {BaseConfig, prompt} = require('./prompts');
-
-/**
- * Reads data from a file present in the provided path.
- * @param {string} path Path of the file/document.
- * @param {string} fileName Name of the file/document.
- * @return {object} file
- */
-function readFile(path, fileName) {
-  if (isValidJSONFile(path)) {
-    const file = getJSONData(path);
-    logger.verbose(
-        `Uploaded ${fileName} successfully from ${path}.\n`.magenta);
-    return file;
-  } else {
-    logger.error(`${fileName} upload failed.`.red);
-    return null;
-  }
-}
 
 /**
  * generates testsuite and creates a testSuite file in the path specified

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -40,6 +40,7 @@ program
         '--testsuitepath <testsuitepath>',
         'path where the generated testsuite is saved',
     )
+    .option('--overridespath <overridespath>', 'Path of Overrides file')
     .option('--verbose', `logs above and equal to 'verbose' level are logged`)
     .action(generateTestSuite);
 
@@ -51,6 +52,7 @@ program
         'testsuite file will be uploaded from testsuitepath',
     )
     .option('--oaspath <oaspath>', 'oas document path')
+    .option('--overridespath <overridespath>', 'Path of Overrides file')
     .option('--baseURL <baseURL>', 'baseURL of the api endpoints')
     .option(
         '--apiendpoints <apiendpoints>',

--- a/src/generators/test_data.js
+++ b/src/generators/test_data.js
@@ -41,12 +41,16 @@ const {
  * Positive testcases include test cases which on execution should get
  * a 2xx http status code from the server.
  * @param {object} schema Schema of request body.
- * @param {object} extras extra keys/fields to be appended to the generated
- *   test case.
- * @return {array<object>} positive testcases
+ * @param {object} extras Extra keys/fields to be appended to the generated
+ *   testcase.
+ * @param {object} overrides Keys/fields of request body and their
+ *  overridden values.
+ * @return {array<object>} Positive testcases.
  */
-function getPostitveTestCaseForRequestBody(schema, extras = {}) {
-  const dataDeficientByOptionalKey = getDataDeficientByOptionalKey(schema);
+function getPostitveTestCaseForRequestBody(
+    schema, extras = {}, overrides = {}) {
+  const dataDeficientByOptionalKey =
+    getDataDeficientByOptionalKey(schema, '$', overrides);
 
   let deficientDatas = [];
   deficientDatas = deficientDatas.concat(dataDeficientByOptionalKey);
@@ -66,16 +70,25 @@ function getPostitveTestCaseForRequestBody(schema, extras = {}) {
  * Negative testcases include test cases which on execution should get
  * a 4xx or 5xx http status code from the server.
  * @param {object} schema Schema of request body.
- * @param {object} extras extra keys/fields to be appended to the generated
- *   test case.
- * @return {array<object>} negative testcases
+ * @param {object} extras Extra keys/fields to be appended to the generated
+ *   testcase.
+ * @param {object} overrides Keys/fields of request body and their
+ *  overridden values.
+ * @return {array<object>} Negative testcases
  */
-function getNegativeTestCaseForRequestBody(schema, extras = {}) {
-  const dataDeficientByDataType = getDataDeficientByDataType(schema);
-  const dataDeficientByEnum = getDataDeficientByEnum(schema);
-  const dataDeficientByNumberLimit = getDataDeficientByNumberLimit(schema);
-  const dataDeficientByRequiredKey = getDataDeficientByRequiredKey(schema);
-  const dataDeficientByStringLength = getDataDeficientByStringLength(schema);
+function getNegativeTestCaseForRequestBody(
+    schema, extras = {}, overrides = {}) {
+  const dataDeficientByDataType = getDataDeficientByDataType(
+      schema, '$', overrides);
+  const dataDeficientByEnum = getDataDeficientByEnum(
+      schema, '$', overrides);
+  const dataDeficientByNumberLimit = getDataDeficientByNumberLimit(
+      schema, '$', {checkMaximum: true, checkMinimum: true}, overrides);
+  const dataDeficientByRequiredKey = getDataDeficientByRequiredKey(
+      schema, '$', overrides);
+  const dataDeficientByStringLength = getDataDeficientByStringLength(
+      schema, '$', {checkMinimumLength: true, checkMaximumLength: true},
+      overrides);
 
   let deficientDatas = [];
   deficientDatas = deficientDatas.concat(dataDeficientByDataType);
@@ -102,18 +115,21 @@ function getNegativeTestCaseForRequestBody(schema, extras = {}) {
  * Example: query params, path params, header params, cookie params.<br>
  * The scope of the functionality is limited to only header parameters.
  * @param {object} parameters Parameter List.
- * @param {object} extras extra keys/fields to be appended to the generated
+ * @param {object} extras Extra keys/fields to be appended to the generated
  *   test case.
- * @return {array<object>} positive testcases
+ * @param {object} overrides Keys/fields of request headers and their
+ *  overridden values.
+ * @return {array<object>} Positive testcases
  */
-function getPostitveTestCaseForRequestHeader(parameters, extras = {}) {
+function getPostitveTestCaseForRequestHeader(
+    parameters, extras = {}, overrides = {}) {
   let deficientDatasOfAllHeaders = [];
   parameters = parameters || [];
   parameters.forEach(function(parameter) {
     if (parameter.in !== 'header') return;
 
-    const dataDeficientByOptionalKey =
-      getDataDeficientByOptionalKey(parameter.schema);
+    const dataDeficientByOptionalKey = getDataDeficientByOptionalKey(
+        parameter.schema, '$', overrides[parameter.name]);
 
     let deficientDatas = [];
     deficientDatas = deficientDatas.concat(dataDeficientByOptionalKey);
@@ -128,7 +144,7 @@ function getPostitveTestCaseForRequestHeader(parameters, extras = {}) {
       under test.
     */
     deficientDatas.forEach(function(deficientData) {
-      const exampleRequestHeader = getMockHeaders(parameters);
+      const exampleRequestHeader = getMockHeaders(parameters, overrides);
       const deficientRequestHeader = exampleRequestHeader;
       deficientRequestHeader[parameter.name] = deficientData.data;
       deficientData.data = deficientRequestHeader;
@@ -137,7 +153,7 @@ function getPostitveTestCaseForRequestHeader(parameters, extras = {}) {
 
     /* Testcase for "missing optional header". */
     if (parameter.required !== true) {
-      const exampleRequestHeader = getMockHeaders(parameters);
+      const exampleRequestHeader = getMockHeaders(parameters, overrides);
       const deficientRequestHeader = exampleRequestHeader;
       delete deficientRequestHeader[parameter.name];
 
@@ -168,26 +184,31 @@ function getPostitveTestCaseForRequestHeader(parameters, extras = {}) {
  * Example: query params, path params, header params, cookie params.<br>
  * The scope of the functionality is limited to only header parameters.
  * @param {object} parameters Parameter List.
- * @param {object} extras extra keys/fields to be appended to the generated
+ * @param {object} extras Extra keys/fields to be appended to the generated
  *   test case.
- * @return {array<object>} negative testcases
+ * @param {object} overrides Keys and their overridden values.
+ * @return {array<object>} Negative testcases.
  */
-function getNegativeTestCaseForRequestHeader(parameters, extras = {}) {
+function getNegativeTestCaseForRequestHeader(
+    parameters, extras = {}, overrides = {}) {
   let deficientDatasOfAllHeaders = [];
   parameters = parameters || [];
   parameters.forEach(function(parameter) {
     if (parameter.in !== 'header') return;
 
-    const dataDeficientByDataType =
-      getDataDeficientByDataType(parameter.schema);
-    const dataDeficientByEnum =
-      getDataDeficientByEnum(parameter.schema);
-    const dataDeficientByNumberLimit =
-      getDataDeficientByNumberLimit(parameter.schema);
-    const dataDeficientByRequiredKey =
-      getDataDeficientByRequiredKey(parameter.schema);
-    const dataDeficientByStringLength =
-      getDataDeficientByStringLength(parameter.schema);
+    const dataDeficientByDataType = getDataDeficientByDataType(
+        parameter.schema, '$', overrides[parameter.name]);
+    const dataDeficientByEnum = getDataDeficientByEnum(
+        parameter.schema, '$', overrides[parameter.name]);
+    const dataDeficientByRequiredKey = getDataDeficientByRequiredKey(
+        parameter.schema, '$', overrides[parameter.name]);
+    const dataDeficientByNumberLimit = getDataDeficientByNumberLimit(
+        parameter.schema, '$', {checkMaximum: true, checkMinimum: true},
+        overrides[parameter.name]);
+    const dataDeficientByStringLength = getDataDeficientByStringLength(
+        parameter.schema, '$',
+        {checkMaximumLength: true, checkMinimumLength: true},
+        overrides[parameter.name]);
 
     let deficientDatas = [];
     deficientDatas = deficientDatas.concat(dataDeficientByDataType);
@@ -206,7 +227,7 @@ function getNegativeTestCaseForRequestHeader(parameters, extras = {}) {
       under test.
     */
     deficientDatas.forEach(function(deficientData) {
-      const exampleRequestHeader = getMockHeaders(parameters);
+      const exampleRequestHeader = getMockHeaders(parameters, overrides);
       const deficientRequestHeader = exampleRequestHeader;
       deficientRequestHeader[parameter.name] = deficientData.data;
       deficientData.data = deficientRequestHeader;
@@ -215,7 +236,7 @@ function getNegativeTestCaseForRequestHeader(parameters, extras = {}) {
 
     /* Testcase for "missing required header". */
     if (parameter.required === true) {
-      const exampleRequestHeader = getMockHeaders(parameters);
+      const exampleRequestHeader = getMockHeaders(parameters, overrides);
       const deficientRequestHeader = exampleRequestHeader;
       delete deficientRequestHeader[parameter.name];
 
@@ -241,9 +262,10 @@ function getNegativeTestCaseForRequestHeader(parameters, extras = {}) {
 /**
  * Generates testsuite for the oasDoc provided.
  * @param {object} oasDoc OAS 3.0 Document.
+ * @param {object} overrides Keys and their overridden values.
  * @return {object} testSuite
  */
-function buildTestSuite(oasDoc) {
+function buildTestSuite(oasDoc, overrides) {
   const testSuite = {};
   testSuite.createdAtTimeStamp = new Date();
 
@@ -278,30 +300,31 @@ function buildTestSuite(oasDoc) {
     const requestBodySchema =
       apiSchema.requestBody.content['application/json'].schema;
     const parameters = apiSchema.parameters;
+
+    const apiEndpointOverrides = (overrides[path] || {})[httpMethod] || {};
+    const requestBodyOverrides = apiEndpointOverrides.requestBody || {};
+    const requestHeaderOverrides = apiEndpointOverrides.requestHeaders || {};
+
     apiTestSuite.examples = {
-      requestBody: getMockData(requestBodySchema),
-      requestHeader: getMockHeaders(parameters),
+      requestBody: getMockData(requestBodySchema, '$', requestBodyOverrides),
+      requestHeader: getMockHeaders(parameters, requestHeaderOverrides),
     };
 
     let positiveTestCases = [];
-    positiveTestCases = positiveTestCases.concat(
-        getPostitveTestCaseForRequestBody(
-            requestBodySchema,
-            {testForRequestBody: true}));
-    positiveTestCases = positiveTestCases.concat(
-        getPostitveTestCaseForRequestHeader(
-            parameters,
-            {testForRequestHeader: true}));
+    positiveTestCases =
+      positiveTestCases.concat(getPostitveTestCaseForRequestBody(
+          requestBodySchema, {testForRequestBody: true}, requestBodyOverrides));
+    positiveTestCases =
+      positiveTestCases.concat(getPostitveTestCaseForRequestHeader(
+          parameters, {testForRequestHeader: true}, requestHeaderOverrides));
 
     let negativeTestCases = [];
-    negativeTestCases = negativeTestCases.concat(
-        getNegativeTestCaseForRequestBody(
-            requestBodySchema,
-            {testForRequestBody: true}));
-    negativeTestCases = negativeTestCases.concat(
-        getNegativeTestCaseForRequestHeader(
-            parameters,
-            {testForRequestHeader: true}));
+    negativeTestCases =
+      negativeTestCases.concat(getNegativeTestCaseForRequestBody(
+          requestBodySchema, {testForRequestBody: true}, requestBodyOverrides));
+    negativeTestCases =
+      negativeTestCases.concat(getNegativeTestCaseForRequestHeader(
+          parameters, {testForRequestHeader: true}, requestHeaderOverrides));
 
     apiTestSuite.testCases = {
       positiveTestCases,
@@ -320,9 +343,10 @@ function buildTestSuite(oasDoc) {
  * output location specified by user.
  * @param {object} oasDoc oas 3.0 document.
  * @param {string} testSuitePath path where the generated testsuite is saved
+ * @param {object} overrides Keys and their overridden values.
  */
-function createTestSuiteFile(oasDoc, testSuitePath) {
-  let testSuite = buildTestSuite(oasDoc);
+function createTestSuiteFile(oasDoc, testSuitePath, overrides) {
+  let testSuite = buildTestSuite(oasDoc, overrides);
   testSuite = JSON.stringify(testSuite);
   try {
     fs.writeFileSync(testSuitePath, testSuite);

--- a/src/utils/app.js
+++ b/src/utils/app.js
@@ -22,6 +22,7 @@
  */
 
 const fs = require('fs');
+const {logger} = require('../log');
 
 /**
  * Generates and returns a random number(integer/float) within the limits set.
@@ -95,10 +96,29 @@ function getJSONData(path) {
   return JSON.parse(jsonObject);
 }
 
+/**
+ * Reads data from a file present in the provided path.
+ * @param {string} path Path of the file/document.
+ * @param {string} fileName Name of the file/document.
+ * @return {object} file
+ */
+function readFile(path, fileName) {
+  if (isValidJSONFile(path)) {
+    const file = getJSONData(path);
+    logger.verbose(
+        `Uploaded ${fileName} successfully from ${path}.\n`.magenta);
+    return file;
+  } else {
+    logger.error(`${fileName} upload failed.`.red);
+    return null;
+  }
+}
+
 module.exports = {
   getRandomNumber,
   getRandomString,
   snakeCase,
+  readFile,
   isValidJSONFile,
   getJSONData,
 };


### PR DESCRIPTION
Fields/keys of request body/headers which requires special/reserved values instead of a randomly generated value are stored in overrides.
Added option: '--overridespath' (path of overrides file)
Example of overrides file:
```
{
  "/pet": {
    "post": {
      "requestBody": {
        "id": 123
      },
      "requestHeaders": {
	     "csrfToken": "asd",
	     "accept": "*"
      }
    }
  }
}
```